### PR TITLE
Implement better type system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /target
-/.wedis
+/.wedis*
 *.code-workspace
 *.vscode
 *.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,8 +164,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "0.16.0+8.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+source = "git+https://github.com/rust-rocksdb/rust-rocksdb?rev=1cf906dc4087f06631820f13855e6b27bd21b972#1cf906dc4087f06631820f13855e6b27bd21b972"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -316,8 +315,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 [[package]]
 name = "rocksdb"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+source = "git+https://github.com/rust-rocksdb/rust-rocksdb?rev=1cf906dc4087f06631820f13855e6b27bd21b972#1cf906dc4087f06631820f13855e6b27bd21b972"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -396,6 +394,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -493,6 +511,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,10 @@ edition = "2021"
 anyhow = "1.0.86"
 concat-string = "1.0.1"
 redcon = "0.1.2"
-rocksdb = "0.22.0"
+# rocksdb 0.22.0 panics when opening a TransactionDB: https://github.com/rust-rocksdb/rust-rocksdb/issues/881
+rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb", rev = "1cf906dc4087f06631820f13855e6b27bd21b972" }
 serde = "1.0.203"
 serde_json = "1.0.119"
+thiserror = "1.0.61"
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/src/commands/generic.rs
+++ b/src/commands/generic.rs
@@ -5,10 +5,14 @@ use crate::database::{Database, DatabaseOperations};
 
 #[tracing::instrument(skip_all)]
 pub fn del(conn: &mut Conn, db: &Database, args: &Vec<Vec<u8>>) -> Result<()> {
+    // TODO: Handle multiple values
     if args.len() != 2 {
         conn.write_error("ERR wrong number of arguments for command");
         return Ok(());
     }
 
-    Ok(db.delete(&args[1])?)
+    let n_fields = db.delete(&args[1])?;
+    conn.write_integer(n_fields);
+
+    Ok(())
 }

--- a/src/commands/generic.rs
+++ b/src/commands/generic.rs
@@ -10,5 +10,5 @@ pub fn del(conn: &mut Conn, db: &Database, args: &Vec<Vec<u8>>) -> Result<()> {
         return Ok(());
     }
 
-    db.delete(&args[1])
+    Ok(db.delete(&args[1])?)
 }

--- a/src/commands/hashes.rs
+++ b/src/commands/hashes.rs
@@ -12,8 +12,8 @@ pub fn hset(conn: &mut Conn, db: &Database, args: &Vec<Vec<u8>>) -> Result<()> {
 
     // TODO: Handle multiple values
     match db.put_hash_field(&args[1], &args[2], &args[3]) {
-        Ok(()) => {
-            conn.write_integer(1);
+        Ok(n_fields) => {
+            conn.write_integer(n_fields);
             Ok(())
         }
         Err(DatabaseError::WrongType { expected: _ }) => {

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,34 +1,104 @@
-use anyhow::Result;
-use rocksdb::{ErrorKind, DB};
+use rocksdb::{ErrorKind, TransactionDB};
+use thiserror::Error;
+
+const TYPE_KEY_PREFIX: &str = "t:";
+const DATA_KEY_PREFIX: &str = "d:";
+
+const TYPE_STRING: &str = "S";
+
+fn prepend_key(key: &[u8], prefix: &[u8]) -> Vec<u8> {
+    [prefix, key].concat()
+}
+
+#[derive(Error, Debug)]
+pub enum DatabaseError {
+    #[error("rocksdb error")]
+    RocksDB(#[from] rocksdb::Error),
+    #[error("unexpected value type (expected {expected:?})")]
+    WrongType { expected: String },
+}
 
 pub struct Database {
-    db: DB,
+    db: TransactionDB,
 }
 
 pub trait DatabaseOperations {
-    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>>;
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError>;
 
-    fn put(&self, key: &[u8], value: &[u8]) -> Result<()>;
+    fn get_string(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError>;
 
-    fn delete(&self, key: &[u8]) -> Result<()>;
+    fn put(&self, key: &[u8], value: &[u8]) -> Result<(), DatabaseError>;
+
+    fn put_string(&self, key: &[u8], value: &[u8]) -> Result<(), DatabaseError>;
+
+    fn delete(&self, key: &[u8]) -> Result<(), DatabaseError>;
 }
 
 impl Database {
-    pub fn new(db: DB) -> Self {
+    pub fn new(db: TransactionDB) -> Self {
         Self { db }
     }
 }
 
 impl DatabaseOperations for Database {
-    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError> {
         Ok(self.db.get(key)?)
     }
 
-    fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+    fn get_string(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError> {
+        let type_key = prepend_key(key, TYPE_KEY_PREFIX.as_bytes());
+        let data_key = prepend_key(key, DATA_KEY_PREFIX.as_bytes());
+
+        let results =
+            self.db
+                .multi_get([type_key, data_key])
+                .into_iter()
+                .fold(Ok(vec![]), |agg, next| {
+                    agg.and_then(|mut v1| {
+                        next.and_then(|v2| {
+                            v1.push(v2);
+                            Ok(v1)
+                        })
+                    })
+                });
+
+        match results {
+            Ok(v) => {
+                let type_value = v[0].as_ref();
+                match type_value {
+                    Some(tv) => {
+                        let data_value = v[1].clone();
+                        if !tv.eq_ignore_ascii_case(TYPE_STRING.as_bytes()) {
+                            Err(DatabaseError::WrongType {
+                                expected: TYPE_STRING.to_string(),
+                            })
+                        } else {
+                            Ok(data_value)
+                        }
+                    }
+                    None => Ok(None),
+                }
+            }
+            Err(err) => Err(DatabaseError::RocksDB(err)),
+        }
+    }
+
+    fn put(&self, key: &[u8], value: &[u8]) -> Result<(), DatabaseError> {
         Ok(self.db.put(key, value)?)
     }
 
-    fn delete(&self, key: &[u8]) -> Result<()> {
+    fn put_string(&self, key: &[u8], value: &[u8]) -> Result<(), DatabaseError> {
+        let type_key = prepend_key(key, TYPE_KEY_PREFIX.as_bytes());
+        let data_key = prepend_key(key, DATA_KEY_PREFIX.as_bytes());
+
+        let txn = self.db.transaction();
+        txn.put(type_key, TYPE_STRING.as_bytes())?;
+        txn.put(data_key, value)?;
+
+        Ok(txn.commit()?)
+    }
+
+    fn delete(&self, key: &[u8]) -> Result<(), DatabaseError> {
         match self.db.delete(key) {
             Ok(_) => Ok(()),
             Err(err) => match err.kind() {

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use rocksdb::{ErrorKind, TransactionDB};
 use thiserror::Error;
 
@@ -5,6 +7,7 @@ const TYPE_KEY_PREFIX: &str = "t:";
 const DATA_KEY_PREFIX: &str = "d:";
 
 const TYPE_STRING: &str = "S";
+const TYPE_HASH: &str = "H";
 
 fn prepend_key(key: &[u8], prefix: &[u8]) -> Vec<u8> {
     [prefix, key].concat()
@@ -14,6 +17,8 @@ fn prepend_key(key: &[u8], prefix: &[u8]) -> Vec<u8> {
 pub enum DatabaseError {
     #[error("rocksdb error")]
     RocksDB(#[from] rocksdb::Error),
+    #[error("serialization error")]
+    Serde(#[from] serde_json::Error),
     #[error("unexpected value type (expected {expected:?})")]
     WrongType { expected: String },
 }
@@ -23,13 +28,13 @@ pub struct Database {
 }
 
 pub trait DatabaseOperations {
-    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError>;
-
     fn get_string(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError>;
 
-    fn put(&self, key: &[u8], value: &[u8]) -> Result<(), DatabaseError>;
+    fn get_hash_field(&self, key: &[u8], field: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError>;
 
     fn put_string(&self, key: &[u8], value: &[u8]) -> Result<(), DatabaseError>;
+
+    fn put_hash_field(&self, key: &[u8], field: &[u8], value: &[u8]) -> Result<(), DatabaseError>;
 
     fn delete(&self, key: &[u8]) -> Result<(), DatabaseError>;
 }
@@ -38,39 +43,43 @@ impl Database {
     pub fn new(db: TransactionDB) -> Self {
         Self { db }
     }
-}
 
-impl DatabaseOperations for Database {
-    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError> {
-        Ok(self.db.get(key)?)
+    fn get_pair<K: AsRef<[u8]>>(
+        &self,
+        key1: K,
+        key2: K,
+    ) -> Result<Vec<Option<Vec<u8>>>, rocksdb::Error> {
+        self.db
+            .multi_get([key1, key2])
+            .into_iter()
+            .fold(Ok(vec![]), |agg, next| {
+                agg.and_then(|mut results| {
+                    next.and_then(|value| {
+                        results.push(value);
+                        Ok(results)
+                    })
+                })
+            })
     }
 
-    fn get_string(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError> {
-        let type_key = prepend_key(key, TYPE_KEY_PREFIX.as_bytes());
-        let data_key = prepend_key(key, DATA_KEY_PREFIX.as_bytes());
+    fn get_typed_value<K: AsRef<[u8]>>(
+        &self,
+        key: K,
+        type_id: &str,
+    ) -> Result<Option<Vec<u8>>, DatabaseError> {
+        let type_key = prepend_key(key.as_ref(), TYPE_KEY_PREFIX.as_bytes());
+        let data_key = prepend_key(key.as_ref(), DATA_KEY_PREFIX.as_bytes());
 
-        let results =
-            self.db
-                .multi_get([type_key, data_key])
-                .into_iter()
-                .fold(Ok(vec![]), |agg, next| {
-                    agg.and_then(|mut v1| {
-                        next.and_then(|v2| {
-                            v1.push(v2);
-                            Ok(v1)
-                        })
-                    })
-                });
-
+        let results = self.get_pair(type_key, data_key);
         match results {
             Ok(v) => {
                 let type_value = v[0].as_ref();
                 match type_value {
                     Some(tv) => {
                         let data_value = v[1].clone();
-                        if !tv.eq_ignore_ascii_case(TYPE_STRING.as_bytes()) {
+                        if !tv.eq_ignore_ascii_case(type_id.as_bytes()) {
                             Err(DatabaseError::WrongType {
-                                expected: TYPE_STRING.to_string(),
+                                expected: type_id.to_string(),
                             })
                         } else {
                             Ok(data_value)
@@ -83,19 +92,67 @@ impl DatabaseOperations for Database {
         }
     }
 
-    fn put(&self, key: &[u8], value: &[u8]) -> Result<(), DatabaseError> {
-        Ok(self.db.put(key, value)?)
-    }
-
-    fn put_string(&self, key: &[u8], value: &[u8]) -> Result<(), DatabaseError> {
-        let type_key = prepend_key(key, TYPE_KEY_PREFIX.as_bytes());
-        let data_key = prepend_key(key, DATA_KEY_PREFIX.as_bytes());
+    fn put_typed_value<K: AsRef<[u8]>, V: AsRef<[u8]>>(
+        &self,
+        key: K,
+        value: V,
+        type_id: &str,
+    ) -> Result<(), DatabaseError> {
+        let type_key = prepend_key(key.as_ref(), TYPE_KEY_PREFIX.as_bytes());
+        let data_key = prepend_key(key.as_ref(), DATA_KEY_PREFIX.as_bytes());
 
         let txn = self.db.transaction();
-        txn.put(type_key, TYPE_STRING.as_bytes())?;
+        txn.put(type_key, type_id.as_bytes())?;
         txn.put(data_key, value)?;
 
         Ok(txn.commit()?)
+    }
+}
+
+impl DatabaseOperations for Database {
+    fn get_string(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError> {
+        self.get_typed_value(key, TYPE_STRING)
+    }
+
+    fn get_hash_field(&self, key: &[u8], field: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError> {
+        let hash = self.get_typed_value(key, TYPE_HASH)?;
+        if let None = hash {
+            return Ok(None);
+        }
+
+        let hash = hash.unwrap();
+        let hash = String::from_utf8_lossy(&hash);
+        let dict: HashMap<String, String> = serde_json::from_str(&hash)?;
+
+        let subkey = String::from_utf8_lossy(field).into_owned();
+        let value = dict.get(&subkey);
+        if let None = value {
+            return Ok(None);
+        }
+
+        let value = value.unwrap();
+        Ok(Some(value.as_bytes().to_vec()))
+    }
+
+    fn put_string(&self, key: &[u8], value: &[u8]) -> Result<(), DatabaseError> {
+        self.put_typed_value(key, value, TYPE_STRING)
+    }
+
+    fn put_hash_field(&self, key: &[u8], field: &[u8], value: &[u8]) -> Result<(), DatabaseError> {
+        // TODO: Update existing hash instead of overwriting it
+        let _ = self.get_typed_value(key, TYPE_HASH)?;
+
+        // TODO: Avoid relying on encoding values as UTF-8 strings
+        let field = String::from_utf8_lossy(field).into_owned();
+        let value = String::from_utf8_lossy(value).into_owned();
+
+        let mut dict = HashMap::new();
+        dict.insert(field, value);
+
+        let value = serde_json::to_string(&dict)?;
+        self.db.put(&key, value.as_bytes())?;
+
+        self.put_typed_value(key, value, TYPE_HASH)
     }
 
     fn delete(&self, key: &[u8]) -> Result<(), DatabaseError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use connection::ConnectionContext;
 use database::Database;
 use redcon::Conn;
-use rocksdb::{Options, DB};
+use rocksdb::{Options, TransactionDB, DB};
 use tracing::{debug, error, info, Level};
 use tracing_subscriber;
 
@@ -53,7 +53,7 @@ fn main() {
 
     let path = ".wedis";
     {
-        let db_raw = DB::open_default(path).expect("Failed to open database");
+        let db_raw = TransactionDB::open_default(path).expect("Failed to open database");
         let db = Database::new(db_raw);
 
         let mut s = redcon::listen("127.0.0.1:6379", db).expect("Failed to start server");


### PR DESCRIPTION
All database keys are prefixed with a `t:` for type metadata, and a `d:` for data. The type metadata fields describe the expected value of the data object with the corresponding key.